### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ English | [中文](./README.zh.md)
 
 This project implements a Model Context Protocol (MCP) server for connecting AI models with Obsidian knowledge bases. Through this server, AI models can directly access and manipulate Obsidian notes, including reading, creating, updating, and deleting notes, as well as managing folder structures.
 
+<a href="https://glama.ai/mcp/servers/@newtype-01/obsidian-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@newtype-01/obsidian-mcp/badge" alt="Obsidian MCP server" />
+</a>
+
 Created by huangyihe
 - Prompt House: https://prompthouse.app/
 - YouTube: https://www.youtube.com/@huanyihe777


### PR DESCRIPTION
This PR adds a badge for the [Obsidian MCP](https://glama.ai/mcp/servers/@newtype-01/obsidian-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@newtype-01/obsidian-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@newtype-01/obsidian-mcp/badge" alt="Obsidian MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.