### PR TITLE
fix: remove anyOf from update_note schema for broad model compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1227,7 +1227,7 @@ class ObsidianMcpServer {
               },
               edits: {
                 type: 'array',
-                description: 'Array of edit operations to apply',
+                description: 'Array of edit operations to apply. Each edit is EITHER a replace (oldText+newText) OR an insert (mode=insert + heading or blockId + content). Runtime validation enforces valid combinations.',
                 items: {
                   type: 'object',
                   properties: {
@@ -1272,12 +1272,9 @@ class ObsidianMcpServer {
                       type: 'string',
                       description: 'Block ID for block-based insertion (^block-id)'
                     }
-                  },
-                  anyOf: [
-                    { required: ['oldText', 'newText'] },     // 替换模式
-                    { required: ['mode', 'heading', 'content'] }, // 标题插入
-                    { required: ['mode', 'blockId', 'content'] }   // 块插入
-                  ]
+                  }
+                  // anyOf removed for broad model compatibility.
+                  // Runtime validation in validateEditOperation() enforces valid field combinations.
                 }
               },
               dryRun: {


### PR DESCRIPTION
## Problem

Some LLM providers (e.g. certain OpenRouter models, local models) do not support `anyOf` with differing `required` fields in JSON Schema for tool parameters. This causes a 400 error when the model tries to call `update_note`:

```
JSON Schema not supported: could not understand the instance `{'required': ['oldText', 'newText']}`
```

## Fix

Removed the `anyOf` block from the `update_note` tool's `edits` item schema. The constraint was redundant - runtime validation in `validateEditOperation()` already enforces valid field combinations:
- Replace mode: requires `oldText` + `newText`
- Insert mode: requires `mode` + (`heading` or `blockId`) + `content`

Also improved the `edits` array description to guide models on valid field combinations.

## Testing

- TypeScript compiles without errors (`tsc --noEmit`)
- Runtime validation logic unchanged - same error messages returned for invalid combinations